### PR TITLE
[WIP] Add Interactive Probing Mode

### DIFF
--- a/octoprint_ublmeshedit/__init__.py
+++ b/octoprint_ublmeshedit/__init__.py
@@ -30,7 +30,25 @@ class UBLMeshEditPlugin(octoprint.plugin.AssetPlugin,
 	def get_settings_defaults(self):
 		return dict(
 			export_gcode_filename="Restore Mesh - {printerName} - {dateTime}.gcode",
-			hide_non_ubl_warning=False
+			hide_non_ubl_warning=False,
+			interactive_probe_pre_gcode=
+				"M18 S3000   ; stepper timeout = 50m\n"
+				"G28         ; home\n"
+				"M420 S1     ; enable the mesh\n"
+				"G90         ; absolute positioning\n"
+				"G0 Z5 F1500 ; move to Z = 5 at 25mm/s\n"
+				"M211 S0     ; disable software endstops\n"
+			,
+			interactive_probe_post_gcode=
+				"G28      ; home\n"
+				"M18 S300 ; stepper timeout = 5m\n"
+				"M84      ; disable steppers\n"
+			,
+			interactive_probe_zfeed=5,
+			interactive_probe_xyfeed=30,
+			interactive_probe_hide_warning=False,
+			interactive_probe_z_hop=5,
+			interactive_probe_at_point_z=0.2
 		)
 
 	def get_template_configs(self):

--- a/octoprint_ublmeshedit/templates/ublmeshedit_settings.jinja2
+++ b/octoprint_ublmeshedit/templates/ublmeshedit_settings.jinja2
@@ -24,4 +24,54 @@
             <span class="help-block">A warning will be shown on the UBL Mesh Editor tab if a non-UBL mesh (some other ABL) is detected. If checked, this warning will be hidden.</span>
         </div>
     </div>
+    <hr>
+    <h4>Interactive Probing</h4>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.ublmeshedit.interactive_probe_hide_warning">Hide warning when enabling
+            </label>
+        </div>
+
+        <label class="control-label">Pre-GCode Commands</label>
+        <div class="controls">
+            <textarea rows="8" id="ublMeshEditSettingsInteractiveProbePreGCode" class="block monospace" data-bind="value: settings.plugins.ublmeshedit.interactive_probe_pre_gcode"></textarea>
+            <span class="help-block">GCode Commands that are run when enabling interactive probing mode. This should include auto homing, enabling the mesh if needed, and optionally heating the bed/hotend and pre-positioning the hotend. Defaults:<br>
+                <pre class="monospace">M18 S3000   ; stepper timeout = 50m
+G28         ; home
+M420 S1     ; enable the mesh
+G90         ; absolute positioning
+G0 Z5 F1500 ; move to Z = 5 at 25mm/s
+M211 S0     ; disable software endstops</pre>
+            </span>
+        </div>
+        
+        <label class="control-label">Post-GCode Commands</label>
+        <div class="controls">
+            <textarea rows="8" id="ublMeshEditSettingsInteractiveProbePostGCode" class="block monospace" data-bind="value: settings.plugins.ublmeshedit.interactive_probe_post_gcode"></textarea>
+            <span class="help-block">GCode Commands that are run when disabling interactive probing mode. Defaults:<br>
+                <pre class="monospace">G28      ; home
+M18 S300 ; stepper timeout = 5m
+M84      ; disable steppers</pre>
+            </span>
+        </div>
+
+        <label class="control-label">Z Feed Rate</label>
+        <div class="controls">
+            <input type="number" id="ublMeshEditSettingsInteractiveProbeZFeed" class="block " data-bind="value: settings.plugins.ublmeshedit.interactive_probe_zfeed">mm/s
+        </div>
+
+        <label class="control-label">X/Y Feed Rate</label>
+        <div class="controls">
+            <input type="number" id="ublMeshEditSettingsInteractiveProbeXYFeed" class="block " data-bind="value: settings.plugins.ublmeshedit.interactive_probe_xyfeed">mm/s
+        </div>
+        <label class="control-label">Z Hop</label>
+        <div class="controls">
+            <input type="number" id="ublMeshEditSettingsInteractiveProbeXYFeed" class="block " data-bind="value: settings.plugins.ublmeshedit.interactive_probe_z_hop">mm
+        </div>
+        <label class="control-label">Z at Point</label>
+        <div class="controls">
+            <input type="number" id="ublMeshEditSettingsInteractiveProbeXYFeed" class="block " data-bind="value: settings.plugins.ublmeshedit.interactive_probe_at_point_z">mm
+        </div>
+    </div>
 </div>

--- a/octoprint_ublmeshedit/templates/ublmeshedit_tab.jinja2
+++ b/octoprint_ublmeshedit/templates/ublmeshedit_tab.jinja2
@@ -10,11 +10,18 @@
         <span class="ubl-mesh-editor-warning">Warning</span>
         <p>This mesh does not look like a Unified Bed Leveling (UBL) mesh. This plugin will attempt to provide limited functionality for it, but some features are disabled and others may not function as expected.</p>
     </div>
+    
     <div id="ublMeshEditorNoMeshInfo" class="ubl-mesh-editor-info" data-bind="visible: showNoMesh">
         <i class="fas fa-info-circle fa-2x"></i>
         <span class="ubl-mesh-editor-warning">No Mesh</span>
         <p>The command completed successfully, but no mesh was detected. If you are sure that you have UBL setup properly and are still getting this message, this may be a bug. Please report it: <a href="https://github.com/The-EG/OctoPrint-UBLMeshEdit/issues/new?assignees=&labels=&template=bug-report.md&title=%5BBUG%5D+New+Issue" target="_blank">Create New Bug Report</a></p>
     </div>
+    <div>
+        <label class="checkbox">
+            <input type="checkbox" data-bind="checked: interactiveProbing">Interactive Probing Mode
+        </label>
+    </div>
+    
     <div id="ublMeshEditorGrid"></div>
     <div>
         <button id="ublMeshEditorGetMeshBtn" class="btn btn-primary" data-bind="click: getMesh, enable: printerState.isReady() && !waitingOK()">
@@ -37,6 +44,12 @@
             <i class="fas fa-crosshairs"></i>
             <span>Save Value</span>
         </button>
+        <!--
+        <button id="ublMeshEditSaveFromProbe" class="btn" data-bind="visible: interactiveProbing">
+            <i class="fas fa-chevron-down"></i>
+            <span>Set from Printer Z</span>
+        </button>
+        -->
     </div>
     <div data-bind="hidden: notUBL">
         <span>Mesh Save Slot:</span><input type="number" data-bind=" value: saveSlot">


### PR DESCRIPTION
Adds a checkbox above the mesh display to enable 'Interactive Probing Mode.'

![image](https://user-images.githubusercontent.com/7342077/110121622-a01bc500-7d8c-11eb-95e9-2c11b2eb6f70.png)

When checked, this will display a warning:
![image](https://user-images.githubusercontent.com/7342077/110121691-b32e9500-7d8c-11eb-918b-2324470f2916.png)

This warning can be hidden with a setting `Hide warning when enabling`.

If the user decides to proceed, the gcode commands specified in the `Pre-GCode Commands` setting are sent to the printer:
![image](https://user-images.githubusercontent.com/7342077/110121903-f7ba3080-7d8c-11eb-876a-dfef9faa6644.png)

And a message is displayed:
![image](https://user-images.githubusercontent.com/7342077/110122031-1b7d7680-7d8d-11eb-8f87-1d6b0da40518.png)

At this point, selecting a point will do the following, in addition to the current behavior:
 1. Move up to `Z Hop` at `Z Feedrate` (plugin settings): `G0 Z{zHop} F{zFeed}`
 2. Move to the selected point at `X/Y Feedrate` (plugin setting): `G42 I{i} J{j} F{xyFeed}`
 3. Move down to `Z at Point` (plugin setting): `G0 Z{zAtPoint} F{zFeed}`

The settings referenced above are configurable:
![image](https://user-images.githubusercontent.com/7342077/110123223-9eeb9780-7d8e-11eb-8d8f-ad0dfc9262d3.png)

Feedrates are specified in mm/s but are converted to mm/min when sending commands to the printer.

When the user unchecks the checkbox to disable Interactive Probing mode, the Post-GCode Commands are sent to the printer:
![image](https://user-images.githubusercontent.com/7342077/110123396-d4908080-7d8e-11eb-8058-a6c2f5e52739.png)

Current functionality in action (click for video):
[![WIP Interactive Probing](https://img.youtube.com/vi/MmBqb2nk6no/0.jpg)](https://www.youtube.com/watch?v=MmBqb2nk6no)

Todo:
 - [ ] Implement 'adjust point' button that will adjust the current point based on the Z position of the hotend
 - [ ] See if I can put printer in a busy state or otherwise alter the State pane to restrict users from starting a print while the mode is active, etc.

Fixes #2

